### PR TITLE
Add mode visualizer module

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,11 @@ local config = {
       inactive_tab_fg = 6,
       new_tab_fg = 2,
     },
+    mode = {
+      enabled = true,
+      icon = wez.nerdfonts.cod_terminal,
+      color = 1,
+    },
     workspace = {
       enabled = true,
       icon = wez.nerdfonts.cod_window,

--- a/plugin/bar/config.lua
+++ b/plugin/bar/config.lua
@@ -29,6 +29,7 @@ local M = {}
 
 ---@class option.modules
 ---@field tabs option.tabs
+---@field mode option.module
 ---@field workspace option.module
 ---@field leader option.module
 ---@field pane option.module
@@ -73,6 +74,11 @@ M.options = {
       active_tab_fg = 4,
       inactive_tab_fg = 6,
       new_tab_fg = 2,
+    },
+    mode = {
+      enabled = true,
+      icon = wez.nerdfonts.cod_terminal,
+      color = 1,
     },
     workspace = {
       enabled = true,

--- a/plugin/bar/mode.lua
+++ b/plugin/bar/mode.lua
@@ -1,0 +1,17 @@
+local M = {}
+
+---Return active key table mode as a user friendly name
+---@param window table
+---@return string
+M.get_mode = function(window)
+  local key_table = window:active_key_table()
+  if not key_table then
+    return ""
+  end
+  if key_table == "copy_mode" then
+    return "copy"
+  end
+  return key_table
+end
+
+return M

--- a/plugin/init.lua
+++ b/plugin/init.lua
@@ -38,6 +38,7 @@ local config = require "bar.config"
 local tabs = require "bar.tabs"
 local user = require "bar.user"
 local spotify = require "bar.spotify"
+local mode = require "bar.mode"
 local paths = require "bar.paths"
 
 ---conforming to https://github.com/wez/wezterm/commit/e4ae8a844d8feaa43e1de34c5cc8b4f07ce525dd
@@ -126,6 +127,14 @@ wez.on("update-status", function(window, pane)
   }
 
   table.insert(left_cells, { Text = string.rep(" ", options.padding.left) })
+
+  if options.modules.mode.enabled then
+    local active = mode.get_mode(window)
+    if #active > 0 then
+      table.insert(left_cells, { Foreground = { Color = palette.ansi[options.modules.mode.color] } })
+      table.insert(left_cells, { Text = options.modules.mode.icon .. utilities._space(active, options.separator.space) })
+    end
+  end
 
   if options.modules.workspace.enabled then
     local stat = options.modules.workspace.icon .. utilities._space(window:active_workspace(), options.separator.space)


### PR DESCRIPTION
## Summary
- add mode visualizer module to show active key table
- insert mode display before workspace section via new module

## Testing
- `stylua plugin/init.lua plugin/bar/config.lua README.md` *(fails: internal error when parsing plugin/init.lua)*
- `luac -p plugin/init.lua plugin/bar/config.lua plugin/bar/mode.lua`

------
https://chatgpt.com/codex/tasks/task_e_6876c95a8f908326ab84f39c9a3f30dc